### PR TITLE
fix a bug with subdirectories

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -19,7 +19,8 @@ exports.resize = (imageBucket, objectKey, width, height) => new Promise((resolve
 
     getFile(imageBucket, objectKey, reject).then(data => {
 
-        const resizedFile = `${os.tmpDir}/resized.${imageBucket}.${objectKey}.${width}.${height}`;
+        const normalizeObjectKey = objectKey.split('/').join('.');
+        const resizedFile = `${os.tmpDir}/resized.${imageBucket}.${normalizeObjectKey}.${width}.${height}`;
 
         const resizeCallback = (err, output, resolve, reject) => {
             if (err) {


### PR DESCRIPTION
Mentioned here: https://github.com/cagataygurturk/image-resizer-service/issues/3

The function crashes if image is in a nested folder, as it does not handle `/` symbols in the temporary file path:
```
2018-11-28T11:10:35.727Z	ERROR 500 null { Error: Command failed: convert: unable to open image `/tmp/resized.bucket.example.com.a/1032/1/example/1/4/screenshots/original.png.300.300': No such file or directory @ error/blob.c/OpenBlob/2643.
convert: WriteBlob Failed `/tmp/resized.bucket.example.com.a/1032/1/example/1/4/screenshots/original.png.300.300' @ error/png.c/MagickPNGErrorHandler/1751.
```

 This PR fixes the issue by replacing `/` with `.` when creating a resized file.
